### PR TITLE
Reduce docker image size to be around 60MB

### DIFF
--- a/setup/docker_setup.sh
+++ b/setup/docker_setup.sh
@@ -13,8 +13,4 @@ FRONTEND_DIR=$(cd "$(dirname "$0")"; cd ../frontend; pwd)
 pushd ${FRONTEND_DIR} > /dev/null
 # build bundle js files
 yarn build
-mkdir -p /var/www/carlaviz
-mv dist/* index.html /var/www/carlaviz/
-mv ../setup/carlaviz /etc/nginx/sites-enabled
-rm -rf *
 popd


### PR DESCRIPTION
Hi,

Thanks a lot for your efforts on the C++ Implementation of XVIZ Protocol that makes it possible to visualize Carla from web browser.

I find that the docker image is pretty large that contains previous build files from protobuf, boost, libcarla, which can be excluded from the final release.

Though build files are removed in **docker_setup.sh**, they are still cached in previous layers of the docker image, making the final release image relatively large:

https://github.com/mjxu96/carlaviz/blob/22b8cb72f572a9f006eac5a47675c9775cff9e75/setup/docker_setup.sh#L9

By staging the builder image as an intermediate image, build files will not be included in the final release image:

```
FROM ubuntu:18.04 AS builder
COPY --from=builder /home/carla/carlaviz/backend/bin/backend /home/carla/carlaviz/backend/bin/backend
```

![image](https://user-images.githubusercontent.com/15157070/118398691-aa422580-b651-11eb-830c-fd42b315c753.png)

![image](https://user-images.githubusercontent.com/15157070/118398681-9dbdcd00-b651-11eb-80bb-01ecc1f112f4.png)

As a result, the docker image image size has been largely reduced:

https://hub.docker.com/r/wuhanstudio/carlaviz/tags?page=1&ordering=last_updated

```
wuhanstudio/carlaviz             latest                          3f468f1cd4d4        25 minutes ago      193MB
mjxu96/carlaviz                  latest                          57c1fe45b586        2 weeks ago         3.06GB
```

Hope you'll find it helpful.

Han