### PR TITLE
[Dockerfile] split frontend backend to different build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,54 @@
-FROM ubuntu:18.04 AS builder
+# Frontend build stage
+FROM node:12-alpine AS frontend
+
+COPY ./frontend /home/carla/carlaviz/frontend
+
+RUN apk --no-cache add git
+
+WORKDIR /home/carla/carlaviz/frontend
+RUN yarn && yarn build
+
+# Backend build stage
+FROM ubuntu:18.04 AS backend
+
+COPY ./backend /home/carla/carlaviz/backend
 
 RUN apt update && \
-  apt install -y wget autoconf automake libtool curl make g++ unzip
+    apt install -y wget autoconf automake libtool curl make g++ unzip
 
 # install protobuf for xviz
-RUN mkdir /home/carla
-RUN mkdir /home/carla/protoc
-RUN cd /home/carla/protoc/ && \
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protobuf-cpp-3.11.2.tar.gz && \
-  tar xvzf protobuf-cpp-3.11.2.tar.gz && \
-  cd protobuf-3.11.2 && \
-  ./configure && \
-  make -j12 && \
-  make install && \
-  ldconfig
+WORKDIR /home/carla/protoc
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protobuf-cpp-3.11.2.tar.gz && \
+    tar xvzf protobuf-cpp-3.11.2.tar.gz && \
+    cd protobuf-3.11.2 && \
+    ./configure && \
+    make -j12 && \
+    make install && \
+    ldconfig
 
 # non-interactive setting for tzdata
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
-  apt install -y git build-essential gcc-7 cmake libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl wget unzip autoconf libtool rsync nginx
+    apt install -y git build-essential gcc-7 cmake libpng-dev libtiff5-dev libjpeg-dev tzdata sed curl wget unzip autoconf libtool rsync
 
-# install nodejs 12.x
-RUN curl -sL https://deb.nodesource.com/setup_12.x |  bash - && \
-  apt-get install -y nodejs
+# build carlaviz backend
+WORKDIR /home/carla/carlaviz/backend
+RUN bash ./setup/setup.sh
+WORKDIR /home/carla/carlaviz/backend/build
+RUN cmake ../ && make backend -j`nproc --all`
 
-# install yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-  apt-get update && apt-get install -y yarn
-
-COPY . /home/carla/carlaviz
-
-# build carlaviz backend and frontend
-RUN cd /home/carla/carlaviz && bash ./setup/setup.sh
-RUN cd /home/carla/carlaviz/frontend && yarn build
-
+# Release stage
 FROM nginx:1.20
 
-# backend
-COPY --from=builder /home/carla/carlaviz/backend/bin/backend /home/carla/carlaviz/backend/bin/backend
-COPY --from=builder /home/carla/protoc/protobuf-3.11.2/src/.libs/libprotobuf.so.22 /lib/x86_64-linux-gnu/libprotobuf.so.22
-
 # frontend
-COPY --from=builder /home/carla/carlaviz/frontend/dist/ /var/www/carlaviz/
-COPY --from=builder /home/carla/carlaviz/frontend/index.html /var/www/carlaviz/index.html
+COPY --from=frontend /home/carla/carlaviz/frontend/dist/ /var/www/carlaviz/
+COPY --from=frontend /home/carla/carlaviz/frontend/index.html /var/www/carlaviz/index.html
 COPY ./docker/carlaviz /etc/nginx/conf.d/default.conf
+
+# backend
+COPY --from=backend /home/carla/carlaviz/backend/bin/backend /home/carla/carlaviz/backend/bin/backend
+COPY --from=backend /home/carla/protoc/protobuf-3.11.2/src/.libs/libprotobuf.so.22 /lib/x86_64-linux-gnu/libprotobuf.so.22
+
 COPY ./docker/run.sh /home/carla/carlaviz/docker/run.sh
 
 EXPOSE 8080-8081
@@ -58,3 +62,4 @@ ENV CARLA_SERVER_PORT 2000
 WORKDIR /home/carla/carlaviz
 
 ENTRYPOINT ["/bin/bash", "./docker/run.sh"]
+


### PR DESCRIPTION
Hi,

It seems that the backend does not require `nodejs` and `yarn`, maybe it's better to split the frontend and backend into different build stages, so that the backend does not need to install nodejs and yarn.

```
# Frontend build stage
FROM node:12-alpine AS frontend

COPY ./frontend /home/carla/carlaviz/frontend

RUN apk --no-cache add git

WORKDIR /home/carla/carlaviz/frontend
RUN yarn && yarn build
```

In this way, the image build process consists of three stages:

- Frontend build
- Backend build
- Release

The build process is now simplified and decoupled, so that **making changes in frontend will not rebuild backend**, and vice versa.

Hope you'll find it useful.
